### PR TITLE
FIXES: Fix `.gitignore`, Fix Issues #4, and #5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,2 @@
-kernel/root/bin/__pycache__/cd.cpython-310.pyc
-kernel/__pycache__/syscheck.cpython-310.pyc
-kernel/__pycache__/tables.cpython-310.pyc
-kernel/root/bin/__pycache__/ls.cpython-310.pyc
-kernel/root/bin/__pycache__/mkdir.cpython-310.pyc
-kernel/root/bin/__pycache__/cat.cpython-310.pyc
-kernel/root/bin/__pycache__/pwd.cpython-310.pyc
-kernel/root/bin/__pycache__/exit.cpython-310.pyc
-kernel/root/bin/__pycache__/logout.cpython-310.pyc
-kernel/root/bin/__pycache__/rm.cpython-310.pyc
-kernel/root/bin/__pycache__/echo.cpython-310.pyc
-kernel/root/bin/__pycache__/touch.cpython-310.pyc
-kernel/root/bin/__pycache__/whoami.cpython-310.pyc
+**/__pycache__/**
+.vscode/

--- a/kernel/root/bin/cat.py
+++ b/kernel/root/bin/cat.py
@@ -13,6 +13,16 @@ def main(self:object, args:list[str]):
     for spam,eggs in enumerate(args):
         if eggs in [">", ">>"]:
             writes.append(spam)
+            user_input = []
+            # get user input until there's a line break
+            print('---USER INPUT---')
+            while True:
+                try:
+                    line = input()
+                except EOFError:
+                    break
+                user_input.append(line)
+            print('---USER INPUT---')
         else:
             paths.append(eggs)
     
@@ -36,28 +46,34 @@ def main(self:object, args:list[str]):
         
         if ">" in args:
             concat = args[:writes[0]] # get the files to concatenate
-            content = ""
+            content = user_input
+            count = 0
             try:
                 for path in concat:
                     try:
                         content += self.read_file(path)
                     except Exception as e:
                         self.cout(f"///ERROR///\n{e}")
-                self.write_file(args[writes[0] + 1], content)
+                while count < len(content):
+                    self.append_file(args[writes[0] + 1], content[count] + "\n")
+                    count += 1
                 print("---SUCCESS---\nFile written successfully.")
             except ValueError as e:
                 self.cout(f"///ERROR///\n{e}")
 
         elif ">>" in args:
             concat = args[:writes[0]]
-            content = ""
+            content = user_input
+            count = 0
             try:
                 for path in concat:
                     try:
                         content += self.read_file(path)
                     except ValueError as e:
                         self.cout(f"///ERROR///\n{e}")
-                self.append_file(args[writes[0] + 1], content)
+                while count < len(content):
+                    self.append_file(args[writes[0] + 1], content[count] + "\n")
+                    count += 1
                 print("---SUCCESS---\nFile appended successfully.")
             except ValueError as e:
                 self.cout(f"///ERROR///\n{e}")

--- a/kernel/root/bin/cd.py
+++ b/kernel/root/bin/cd.py
@@ -8,7 +8,11 @@ def main(self:object, args:list[str]):
         self.cout("///USAGE///\ncd dir")
         return
     target = os.path.normpath(os.path.join(self.current_directory, args[0]))
-    try:
-        self.change_directory(target)
-    except ValueError as e:
-        print(f"///ERROR///\n{e}")
+    is_a_dir = os.path.isdir(target)
+    if not is_a_dir:
+        print(f"///ERROR///\n'{target}' isn't a directory")
+    else:
+        try:
+            self.change_directory(target)
+        except ValueError as e:
+            print(f"///ERROR///\n{e}")


### PR DESCRIPTION
# FIXES/FEATURES

This PR fix the `.gitignore` so that it's more optimized.

This PR also fixes both issue #4 and #5:

## Issue 4

When running the `cat` command with a `>` or `>>` following, it will create a loop to get multi-line input from the user, which will stop with Ctrl+D command. It will after print the user input the to entered file.

## Issue 5

Simply add a boolean variable that tells the script if the selected 'item' is a directory or not. Will output an error if it isn't a directory.

## Tests

Everything that's been changed is tested.