### PR TITLE
OUTPUT CHANGES: make `<user>@<machine> <level>` thing bold + change pwd output + add `mv` command

### DIFF
--- a/kernel/master.py
+++ b/kernel/master.py
@@ -73,7 +73,7 @@ class Terminal:
         'initialise the system.'
         while True:
             to_strip = len(self.clipout)
-            dir_prompt:str = f"{self.user.lower()}@PathOS:{self.current_directory[to_strip:].lower()}/ $ "
+            dir_prompt:str = f"\033[1m{self.user.lower()}@PathOS:{self.current_directory[to_strip:].lower()}/ $ \033[0m"
             self.cout(dir_prompt,endl="")
             comm = input()
             if not comm:

--- a/kernel/master.py
+++ b/kernel/master.py
@@ -8,6 +8,8 @@ import tables
 
 ######## refactored form of the original code ---version 0.0.2 ########
 
+os.system('clear')
+
 @dataclass
 class Terminal:
     user:str = "root"
@@ -565,3 +567,4 @@ class Terminal:
     
     
 terminal = Terminal()
+

--- a/kernel/root/bin/mv.py
+++ b/kernel/root/bin/mv.py
@@ -1,0 +1,20 @@
+import os
+import shutil
+
+# move an item into a new location
+
+def main(self:object, args: list[str]):
+    if len(args) < 2 or "--h" in args:
+        self.cout("///USAGE///\nmv <current location> <new location>")
+        return
+    else:
+        # check if first location exists
+        item = os.path.join(self.current_directory, args[0])
+        new_location = os.path.join(self.current_directory, args[1])
+        try:
+            if not os.path.exists(item):
+                self.cout(f"///ERROR///\nitem '{item}' does not exist")
+            else:
+                shutil.move(item, new_location)
+        except Exception as error:
+            self.cout(f"///ERROR///\n{error}")

--- a/kernel/root/bin/pwd.py
+++ b/kernel/root/bin/pwd.py
@@ -8,6 +8,6 @@ def main(self:object, args:list[str]):
         return
     pwd = self.ret_pwd()
     if not pwd:
-        self.cout("---SYSTEM ROOT DETECTED---")
+        self.cout("Working Dir: '/'")
         return
-    self.cout(pwd)
+    self.cout(f"Working Dir: '{pwd}'")


### PR DESCRIPTION
This PR changes how the pwd output and how make the `<user>@<machine> <level>` thing bold:

![Screenshot from 2024-02-18 16-51-42](https://github.com/Monarchz3ro/Silver/assets/87318892/a8ca9a15-0df0-4be5-b9f7-cf0cbe587d89)

I think it's better like that.

This PR now adds the `mv` command and a `os.system('clear')` at the beginning of the program.